### PR TITLE
fix: Update @types/prettier to 2.6.0 in projen

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "@types/prettier",
-      "version": "v2.6.0",
+      "version": "2.6.0",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -31,7 +31,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'constructs',
     'aws-cdk-lib',
     'aws-sdk',
-    '@types/prettier@v2.6.0',
+    '@types/prettier@2.6.0',
     '@types/change-case',
   ],
   bundledDeps: [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/change-case": "^2.3.1",
     "@types/jest": "^27",
     "@types/node": "^14",
-    "@types/prettier": "v2.6.0",
+    "@types/prettier": "2.6.0",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "aws-cdk-lib": "2.24.1",


### PR DESCRIPTION
Update @types/prettier to 2.6.0 in projen, generate updated package.json. Fixes install error on npm 8
